### PR TITLE
Ldlink 3.1

### DIFF
--- a/LDlink/LDlink.js
+++ b/LDlink/LDlink.js
@@ -75,6 +75,7 @@ $(document).ready(function() {
     });
 
     $("#example-gwas").click(function(e){
+      console.log("Use example GWAS data.");
       var useEx = document.getElementById('example-gwas');
       // var exampleHeaders = ['A', 'B', 'C'];
       if (useEx.checked){
@@ -96,7 +97,11 @@ $(document).ready(function() {
           $("#assoc-p-value > button").text("P-Value: p column");
         });
 
-        console.log("Use example GWAS data.");
+        $('#region-gene-name').val('');
+        $('#region-gene-index').val('');
+        $('#region-variant-index').val('');
+
+
         $("#assoc-region > .btn:first-child").val("Region".toLowerCase());
         $("#assoc-region > .btn:first-child").text("Region");
         // var element = document.getElementById('region-codes-menu1');
@@ -112,7 +117,9 @@ $(document).ready(function() {
         console.log($("#region-region-end-coord").val());
         console.log($("#region-region-index").val());
 
-        // $("#ldassoc-population-codes").val(["CEU"]);
+        $("#ldassoc-population-codes").val('');
+        refreshPopulation([],"ldassoc");
+        $("#ldassoc-population-codes").val(["CEU"]);
         refreshPopulation(["CEU"],"ldassoc");
         console.log($("#ldassoc-population-codes").val());
       }else{

--- a/LDlink/LDlink.js
+++ b/LDlink/LDlink.js
@@ -63,12 +63,36 @@ $(document).ready(function() {
         console.log(e.target.id);
         switch($(this).text()) {
             case "Gene":
+                $("#region-gene-name").val('');
+                // $("#region-gene-base-pair-window").val('');
+                $("#region-gene-index").val('');
+                $("#region-region-start-coord").val('');
+                $("#region-region-end-coord").val('');
+                $("#region-region-index").val('');
+                $("#region-variant-index").val('');
+                // $("#region-variant-base-pair-window").val('');
                 $("#region-gene-container").show();
                 break;
             case "Region":
+                $("#region-gene-name").val('');
+                // $("#region-gene-base-pair-window").val('');
+                $("#region-gene-index").val('');
+                $("#region-region-start-coord").val('');
+                $("#region-region-end-coord").val('');
+                $("#region-region-index").val('');
+                $("#region-variant-index").val('');
+                // $("#region-variant-base-pair-window").val('');
                 $("#region-region-container").show();
                 break;
             case "Variant":
+                $("#region-gene-name").val('');
+                // $("#region-gene-base-pair-window").val('');
+                $("#region-gene-index").val('');
+                $("#region-region-start-coord").val('');
+                $("#region-region-end-coord").val('');
+                $("#region-region-index").val('');
+                $("#region-variant-index").val('');
+                // $("#region-variant-base-pair-window").val('');
                 $("#region-variant-container").show();
                 break;
         }


### PR DESCRIPTION
-fixed bug regarding fields not being reset when a new region dropdown option is selected.
-when there is an error in one field and the field's container is hid, validations would prevent it from 'calculating' with new and correct data