### PR TITLE
add robots.txt in root directory to fix 404 errors for missing robots…

### DIFF
--- a/LDlink/robots.txt
+++ b/LDlink/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
I added robots.txt file in root directory and try to fix the 404 errors which missing robots.txt; 
Also another Line <link rel="shortcut icon" href="LD.ico" type="image/x-icon"> was added to index.html to solve 404 errors of missing icons.