### PR TITLE
Dev improve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ config.yml
 
 .env
 **mcp.json
+*.plan.md
+ldlink-autoscaling-next-steps.md

--- a/server/ApiAccess.py
+++ b/server/ApiAccess.py
@@ -320,18 +320,36 @@ def checkLocked(token):
             return False
 
 def toggleLocked(token, lock):
-    if config['restrict_concurrency']:
-        db = connectMongoDBReadOnly(False,True,True)
-        users = db.api_users
-        record = users.find_one({"token": token})
+    if not config['restrict_concurrency']:
+        return True
 
-        # bypass lock toggle if user has -1 locked flag set (unlimited api calls)
-        if record["locked"] != -1:
-            if lock == 1:
-                calcStartTime = getDatetime()
-                users.find_one_and_update({"token": token}, { "$set": {"locked": calcStartTime}})
-            else: 
-                users.find_one_and_update({"token": token}, { "$set": {"locked": lock}})
+    db = connectMongoDBReadOnly(False,True,True)
+    users = db.api_users
+    record = users.find_one({"token": token})
+
+    if record is None:
+        return False
+
+    # bypass lock toggle if user has -1 locked flag set (unlimited api calls)
+    if record.get("locked") == -1:
+        return True
+
+    if lock == 1:
+        calcStartTime = getDatetime()
+        update_result = users.find_one_and_update(
+            {
+                "token": token,
+                "$or": [
+                    {"locked": 0},
+                    {"locked": {"$exists": False}}
+                ]
+            },
+            {"$set": {"locked": calcStartTime}}
+        )
+        return update_result is not None
+
+    users.find_one_and_update({"token": token}, {"$set": {"locked": lock}})
+    return True
 
 # check if email is blocked (1=blocked, 0=not blocked). returns true if email is blocked
 def checkBlockedEmail(email):

--- a/server/LDlink.py
+++ b/server/LDlink.py
@@ -1960,7 +1960,8 @@ def ldexpress():
         )
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             (query_snps, thinned_snps, thinned_genes, thinned_tissues, details, errors_warnings) = calculate_express(
                 snplist,
                 pop,
@@ -2096,7 +2097,8 @@ def ldhap():
             f.write(snps.lower())
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             out_json = calculate_hap(snplst, pop, reference, web, genome_build)
             if "error" in json.loads(out_json):
                 toggleLocked(token, 0)
@@ -2234,7 +2236,8 @@ def ldmatrix():
             f.write(snps.lower())
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             out_script, out_div = calculate_matrix(
                 snplst, pop, reference, web, str(request.method), genome_build, r2_d, collapseTranscript
             )
@@ -2368,7 +2371,8 @@ def ldpair():
         # print('request: ' + str(reference))
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             out_json = calculate_pair(snp_pairs, pop, web, genome_build, reference)
             # if there is error, the out_json should be json format not as array
             if "error" in json.loads(out_json):
@@ -2484,7 +2488,8 @@ def ldpop():
         # print('request: ' + str(reference))
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             out_json = calculate_pop(var1, var2, pop, r2_d, web, genome_build, reference)
             if "error" in json.loads(out_json):
                 toggleLocked(token, 0)
@@ -2600,7 +2605,8 @@ def ldproxy():
         )
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             out_script, out_div = calculate_proxy(
                 var, pop, reference, web, genome_build, r2_d, int(window), collapseTranscript
             )
@@ -2770,7 +2776,8 @@ def ldtrait():
                     f.write(s.lower() + "\n")
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             app.logger.debug("begin to call trait")
             print("####################")
             print(snpfile, pop, r2_d, r2_d_threshold, reference, genome_build, window)
@@ -2950,7 +2957,8 @@ def ldtraitgwas():
                     f.write(s.lower() + "\n")
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             app.logger.debug("begin to call trait")
             print("####################")
             print(snpfile, pop, r2_d, r2_d_threshold, reference, genome_build, window)
@@ -3119,7 +3127,8 @@ def ldexpressgwas():
         )
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             (query_snps, thinned_snps, thinned_genes, thinned_tissues, details, errors_warnings) = calculate_express(
                 snplist,
                 pop,
@@ -3246,7 +3255,8 @@ def snpchip():
             f.write(snps.lower())
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             snp_chip = calculate_chip(snplst, platforms, web, reference, genome_build)
             if "error" in json.loads(snp_chip) and len(json.loads(snp_chip)["error"]) > 0:
                 toggleLocked(token, 0)
@@ -3399,7 +3409,8 @@ def snpclip():
                     f.write(s.lower() + "\n")
         try:
             # lock token preventing concurrent requests
-            toggleLocked(token, 1)
+            if not toggleLocked(token, 1):
+                return sendTraceback("Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov")
             (snps, snp_list, details) = calculate_clip(
                 snpfile, pop, reference, web, genome_build, float(r2_threshold), float(maf_threshold)
             )

--- a/server/LDutilites.py
+++ b/server/LDutilites.py
@@ -73,7 +73,7 @@ def unlock_stale_tokens(db, lock_timeout = 15 * 60):
                     diff = present - locked
                 else:
                     diff = present - dateutil.parser.parse(locked, ignoretz=True)
-                diffSeconds = (diff.seconds % 3600)
+                diffSeconds = diff.total_seconds()
                 # if token is locked for over 15 mins, unlock
                 if diffSeconds > lock_timeout:
                     unlockTokens.append(user["token"])

--- a/server/UnlockStaleTokens.py
+++ b/server/UnlockStaleTokens.py
@@ -24,7 +24,7 @@ def main():
                     diff = present - locked
                 else:
                     diff = present - dateutil.parser.parse(locked, ignoretz=True)
-                diffMinutes = (diff.seconds % 3600) // 60.0
+                diffMinutes = diff.total_seconds() / 60.0
                 # if token is locked for over 15 mins, unlock
                 if diffMinutes > 15.0:
                     unlockTokens.append(user["token"])


### PR DESCRIPTION
### 1) Atomic lock acquisition

- Replace check-then-set logic with one MongoDB conditional update in lock acquire path.
- Keep unlock as a separate release step.
- Return explicit acquire status so caller can reject concurrent requests.

### 2) Fix stale-lock cleanup

- Replace diff.seconds % 3600 with diff.total_seconds() in stale unlock jobs.
- Validate both runtime thread cleanup and external unlock script behavior.
