### PR TITLE
Dev quotalimit

### DIFF
--- a/.github/aws/api.yml
+++ b/.github/aws/api.yml
@@ -92,6 +92,8 @@ containerDefinitions:
         valueFrom: "/analysistools/${TIER}/${APP}/token_lock_timeout"
       - name: RESTRICT_CONCURRENCY
         valueFrom: "/analysistools/${TIER}/${APP}/restrict_concurrency"
+      - name: RUNTIME_LIMIT_MS_24H
+        valueFrom: "/analysistools/${TIER}/${APP}/runtime_limit_ms_24h"
       - name: EMAIL_SMTP_HOST
         valueFrom: "/analysistools/${TIER}/${APP}/email_smtp_host"
       - name: EMAIL_ADMIN

--- a/.github/aws/api.yml
+++ b/.github/aws/api.yml
@@ -94,6 +94,8 @@ containerDefinitions:
         valueFrom: "/analysistools/${TIER}/${APP}/restrict_concurrency"
       - name: RUNTIME_LIMIT_MS_24H
         valueFrom: "/analysistools/${TIER}/${APP}/runtime_limit_ms_24h"
+      - name: RUNTIME_BLOCK_COOLDOWN_MINUTES
+        valueFrom: "/analysistools/${TIER}/${APP}/runtime_block_cooldown_minutes"
       - name: EMAIL_SMTP_HOST
         valueFrom: "/analysistools/${TIER}/${APP}/email_smtp_host"
       - name: EMAIL_ADMIN

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ config.yml
 
 .env
 **mcp.json
+
+*.plan.md
+*steps.md

--- a/server/ApiAccess.py
+++ b/server/ApiAccess.py
@@ -154,7 +154,7 @@ def insertUser(firstname, lastname, email, institution, token, registered, block
     users.insert_one(user).inserted_id
 
 # log token's api call to api_log table
-def logAccess(token, module):
+def logAccess(token, module, duration_ms=None):
     db = connectMongoDBReadOnly(False,True,True)
     accessed = getDatetime()
     
@@ -163,6 +163,8 @@ def logAccess(token, module):
         "module": module,
         "accessed": accessed
     }
+    if duration_ms is not None:
+        log["duration_ms"] = int(duration_ms)
     logs = db.api_log
     logs.insert_one(log).inserted_id
 

--- a/server/ApiAccess.py
+++ b/server/ApiAccess.py
@@ -13,6 +13,20 @@ from LDcommon import connectMongoDBReadOnly,getEmail,get_config
 # blocked users attribute: 0=false, 1=true
 
 config = get_config()
+RUNTIME_BLOCK_REASON = "runtime_limit"
+RUNTIME_BLOCK_COOLDOWN_HOURS = 12
+
+
+def _parse_datetime(value):
+    if isinstance(value, datetime.datetime):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().replace("Z", "+00:00")
+        try:
+            return datetime.datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+    return None
 
 # connect to email account
 def smtp_connect(email_account):
@@ -209,7 +223,10 @@ def blockUser(email, url_root):
     }
     db = connectMongoDBReadOnly(False,True)
     users = db.api_users
-    update_operation = users.find_one_and_update({"email": email}, { "$set": {"blocked": 1}})
+    update_operation = users.find_one_and_update(
+        {"email": email},
+        {"$set": {"blocked": 1, "blocked_reason": "admin_manual", "blocked_at": getDatetime(), "blocked_until": None}}
+    )
     if update_operation is None:
         return None
     emailUserBlocked(email, email_account, url_root)
@@ -234,7 +251,17 @@ def blockToken(token, url_root):
             "message": "Token is already blocked."
         }
 
-    update_result = users.find_one_and_update({"token": token}, { "$set": {"blocked": 1}})
+    blocked_at = getDatetime()
+    blocked_until = blocked_at + datetime.timedelta(hours=RUNTIME_BLOCK_COOLDOWN_HOURS)
+    update_result = users.find_one_and_update(
+        {"token": token},
+        {"$set": {
+            "blocked": 1,
+            "blocked_reason": RUNTIME_BLOCK_REASON,
+            "blocked_at": blocked_at,
+            "blocked_until": blocked_until,
+        }}
+    )
     print(f"[blockToken] Updated token to blocked: token={token} email={email} update_result={update_result is not None}")
 
     if email:
@@ -256,7 +283,10 @@ def unblockUser(email):
     }
     db = connectMongoDBReadOnly(False,True)
     users = db.api_users
-    update_operation = users.find_one_and_update({"email": email}, { "$set": {"blocked": 0}})
+    update_operation = users.find_one_and_update(
+        {"email": email},
+        {"$set": {"blocked": 0, "blocked_reason": None, "blocked_at": None, "blocked_until": None}}
+    )
     if update_operation is None:
         return None
     emailUserUnblocked(email, email_account)
@@ -365,10 +395,32 @@ def checkBlocked(token):
     if record is None:
         return False
     else:
-        if int(record["blocked"]) == 1:
-            return True
-        else:
+        if int(record.get("blocked", 0)) != 1:
             return False
+
+        # Only runtime-limit blocks auto-expire. Other block reasons stay blocked.
+        if record.get("blocked_reason") == RUNTIME_BLOCK_REASON:
+            now = getDatetime()
+            blocked_until = record.get("blocked_until")
+
+            if blocked_until is None:
+                blocked_at = record.get("blocked_at")
+                if blocked_at is not None:
+                    blocked_at = _parse_datetime(blocked_at)
+                    if blocked_at is not None:
+                        blocked_until = blocked_at + datetime.timedelta(hours=RUNTIME_BLOCK_COOLDOWN_HOURS)
+
+            if blocked_until is not None:
+                blocked_until = _parse_datetime(blocked_until)
+                if blocked_until is not None and now >= blocked_until:
+                    users.find_one_and_update(
+                        {"token": token},
+                        {"$set": {"blocked": 0, "blocked_reason": None, "blocked_at": None, "blocked_until": None}}
+                    )
+                    print(f"[checkBlocked] Auto-unblocked runtime-limited token after cooldown: {token}")
+                    return False
+
+        return True
 
 # check if token is locked (1=locked, 0=not locked, -1=never locked). returns true (1) if token is locked
 def checkLocked(token):

--- a/server/ApiAccess.py
+++ b/server/ApiAccess.py
@@ -404,19 +404,23 @@ def getToken(email):
     else:
         return record["token"]
 
-# check if token is blocked (1=blocked, 0=not blocked). returns true if token is blocked
+# check if token is blocked (1=blocked, 0=not blocked). returns (is_blocked, reason) tuple
+# is_blocked: True if token is currently blocked, False otherwise
+# reason: 'runtime_limit' or other reason string if blocked, None if not blocked
 def checkBlocked(token):
     db = connectMongoDBReadOnly(False,True,True)
     users = db.api_users
     record = users.find_one({"token": token})
     if record is None:
-        return False
+        return (False, None)
     else:
         if int(record.get("blocked", 0)) != 1:
-            return False
+            return (False, None)
+
+        blocked_reason = record.get("blocked_reason", "unknown")
 
         # Only runtime-limit blocks auto-expire. Other block reasons stay blocked.
-        if record.get("blocked_reason") == RUNTIME_BLOCK_REASON:
+        if blocked_reason == RUNTIME_BLOCK_REASON:
             now = getDatetime()
             blocked_until = record.get("blocked_until")
 
@@ -443,9 +447,9 @@ def checkBlocked(token):
                         }
                     )
                     print(f"[checkBlocked] Auto-unblocked runtime-limited token after cooldown: {token}")
-                    return False
+                    return (False, None)
 
-        return True
+        return (True, blocked_reason)
 
 # check if token is locked (1=locked, 0=not locked, -1=never locked). returns true (1) if token is locked
 def checkLocked(token):

--- a/server/ApiAccess.py
+++ b/server/ApiAccess.py
@@ -14,16 +14,21 @@ from LDcommon import connectMongoDBReadOnly,getEmail,get_config
 
 config = get_config()
 RUNTIME_BLOCK_REASON = "runtime_limit"
-RUNTIME_BLOCK_COOLDOWN_HOURS = 12
+RUNTIME_BLOCK_COOLDOWN_MINUTES = int(config.get("runtime_block_cooldown_minutes", 120))
 
 
 def _parse_datetime(value):
     if isinstance(value, datetime.datetime):
+        if value.tzinfo is not None:
+            return value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
         return value
     if isinstance(value, str):
         normalized = value.strip().replace("Z", "+00:00")
         try:
-            return datetime.datetime.fromisoformat(normalized)
+            parsed = datetime.datetime.fromisoformat(normalized)
+            if parsed.tzinfo is not None:
+                return parsed.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+            return parsed
         except ValueError:
             return None
     return None
@@ -187,13 +192,22 @@ def logAccess(token, module, duration_ms=None):
 def getTokenRuntimeLast24Hours(token):
     db = connectMongoDBReadOnly(False,True,True)
     logs = db.api_log
+    users = db.api_users
     window_start = getDatetime() - datetime.timedelta(hours=24)
+    effective_window_start = window_start
+
+    user_record = users.find_one({"token": token}, {"runtime_budget_reset_at": 1})
+    runtime_budget_reset_at = None
+    if user_record is not None:
+        runtime_budget_reset_at = _parse_datetime(user_record.get("runtime_budget_reset_at"))
+        if runtime_budget_reset_at is not None and runtime_budget_reset_at > effective_window_start:
+            effective_window_start = runtime_budget_reset_at
 
     pipeline = [
         {
             "$match": {
                 "token": token,
-                "accessed": {"$gte": window_start},
+                "accessed": {"$gte": effective_window_start},
                 "duration_ms": {"$exists": True}
             }
         },
@@ -212,7 +226,10 @@ def getTokenRuntimeLast24Hours(token):
     else:
         total_ms = int(result[0].get("total_duration_ms", 0))
     
-    print(f"[getTokenRuntimeLast24Hours] token={token} window_start={window_start} total_ms={total_ms}")
+    print(
+        f"[getTokenRuntimeLast24Hours] token={token} window_start={window_start} "
+        f"effective_window_start={effective_window_start} runtime_budget_reset_at={runtime_budget_reset_at} total_ms={total_ms}"
+    )
     return total_ms
 
 # sets blocked attribute of user to 1=true
@@ -252,7 +269,7 @@ def blockToken(token, url_root):
         }
 
     blocked_at = getDatetime()
-    blocked_until = blocked_at + datetime.timedelta(hours=RUNTIME_BLOCK_COOLDOWN_HOURS)
+    blocked_until = blocked_at + datetime.timedelta(minutes=RUNTIME_BLOCK_COOLDOWN_MINUTES)
     update_result = users.find_one_and_update(
         {"token": token},
         {"$set": {
@@ -408,14 +425,22 @@ def checkBlocked(token):
                 if blocked_at is not None:
                     blocked_at = _parse_datetime(blocked_at)
                     if blocked_at is not None:
-                        blocked_until = blocked_at + datetime.timedelta(hours=RUNTIME_BLOCK_COOLDOWN_HOURS)
+                        blocked_until = blocked_at + datetime.timedelta(minutes=RUNTIME_BLOCK_COOLDOWN_MINUTES)
 
             if blocked_until is not None:
                 blocked_until = _parse_datetime(blocked_until)
                 if blocked_until is not None and now >= blocked_until:
                     users.find_one_and_update(
                         {"token": token},
-                        {"$set": {"blocked": 0, "blocked_reason": None, "blocked_at": None, "blocked_until": None}}
+                        {
+                            "$set": {
+                                "blocked": 0,
+                                "blocked_reason": None,
+                                "blocked_at": None,
+                                "blocked_until": None,
+                                "runtime_budget_reset_at": now,
+                            }
+                        }
                     )
                     print(f"[checkBlocked] Auto-unblocked runtime-limited token after cooldown: {token}")
                     return False

--- a/server/ApiAccess.py
+++ b/server/ApiAccess.py
@@ -192,9 +192,14 @@ def getTokenRuntimeLast24Hours(token):
     ]
 
     result = list(logs.aggregate(pipeline))
+    total_ms = 0
     if len(result) == 0:
-        return 0
-    return int(result[0].get("total_duration_ms", 0))
+        total_ms = 0
+    else:
+        total_ms = int(result[0].get("total_duration_ms", 0))
+    
+    print(f"[getTokenRuntimeLast24Hours] token={token} window_start={window_start} total_ms={total_ms}")
+    return total_ms
 
 # sets blocked attribute of user to 1=true
 def blockUser(email, url_root):
@@ -219,18 +224,25 @@ def blockToken(token, url_root):
     record = users.find_one({"token": token})
 
     if record is None:
+        print(f"[blockToken] Token not found in api_users: {token}")
         return None
 
+    email = record.get("email")
     if int(record.get("blocked", 0)) == 1:
+        print(f"[blockToken] Token already blocked: {token} (email={email})")
         return {
             "message": "Token is already blocked."
         }
 
-    users.find_one_and_update({"token": token}, { "$set": {"blocked": 1}})
+    update_result = users.find_one_and_update({"token": token}, { "$set": {"blocked": 1}})
+    print(f"[blockToken] Updated token to blocked: token={token} email={email} update_result={update_result is not None}")
 
-    email = record.get("email")
     if email:
-        emailUserBlocked(email, email_account, url_root)
+        try:
+            emailUserBlocked(email, email_account, url_root)
+            print(f"[blockToken] Sent blocked email to: {email}")
+        except Exception as e:
+            print(f"[blockToken] Failed to send email to {email}: {e}")
 
     return {
         "message": "Token has been blocked due to runtime limit policy."

--- a/server/ApiAccess.py
+++ b/server/ApiAccess.py
@@ -168,6 +168,34 @@ def logAccess(token, module, duration_ms=None):
     logs = db.api_log
     logs.insert_one(log).inserted_id
 
+
+# sum token runtime from api_log over a rolling 24-hour window
+def getTokenRuntimeLast24Hours(token):
+    db = connectMongoDBReadOnly(False,True,True)
+    logs = db.api_log
+    window_start = getDatetime() - datetime.timedelta(hours=24)
+
+    pipeline = [
+        {
+            "$match": {
+                "token": token,
+                "accessed": {"$gte": window_start},
+                "duration_ms": {"$exists": True}
+            }
+        },
+        {
+            "$group": {
+                "_id": None,
+                "total_duration_ms": {"$sum": "$duration_ms"}
+            }
+        }
+    ]
+
+    result = list(logs.aggregate(pipeline))
+    if len(result) == 0:
+        return 0
+    return int(result[0].get("total_duration_ms", 0))
+
 # sets blocked attribute of user to 1=true
 def blockUser(email, url_root):
     email_account = getEmail()
@@ -181,6 +209,32 @@ def blockUser(email, url_root):
         return None
     emailUserBlocked(email, email_account, url_root)
     return out_json
+
+
+# sets blocked attribute of token owner to 1=true
+def blockToken(token, url_root):
+    email_account = getEmail()
+    db = connectMongoDBReadOnly(False,True)
+    users = db.api_users
+    record = users.find_one({"token": token})
+
+    if record is None:
+        return None
+
+    if int(record.get("blocked", 0)) == 1:
+        return {
+            "message": "Token is already blocked."
+        }
+
+    users.find_one_and_update({"token": token}, { "$set": {"blocked": 1}})
+
+    email = record.get("email")
+    if email:
+        emailUserBlocked(email, email_account, url_root)
+
+    return {
+        "message": "Token has been blocked due to runtime limit policy."
+    }
 
 # sets blocked attribute of user to 0=false
 def unblockUser(email):

--- a/server/LDlink.py
+++ b/server/LDlink.py
@@ -373,10 +373,16 @@ def requires_token(f):
                         + "?tab=apiaccess"
                     )
                 # Check if token is blocked
-                if checkBlocked(token):
-                    return sendTraceback(
-                        "Your API token has been blocked. Please contact system administrator: NCILDlinkWebAdmin@mail.nih.gov"
-                    )
+                is_blocked, blocked_reason = checkBlocked(token)
+                if is_blocked:
+                    if blocked_reason == "runtime_limit":
+                        return sendTraceback(
+                            "Your API token has been blocked because runtime usage exceeded the 24-hour test limit. Please contact system administrator: NCILDlinkWebAdmin@mail.nih.gov"
+                        )
+                    else:
+                        return sendTraceback(
+                            "Your API token has been blocked. Please contact system administrator: NCILDlinkWebAdmin@mail.nih.gov"
+                        )
                 # Check if token is locked (exclude check on api server 2)
                 if "LDlinkRest" in request.full_path:
                     if checkLocked(token):

--- a/server/LDlink.py
+++ b/server/LDlink.py
@@ -318,6 +318,12 @@ def read_csv_headers(example_filepath):
 def getModule(fullPath):
     if "ldexpress" in fullPath:
         return "LDexpress"
+    elif "ldscore" in fullPath:
+        return "LDscore"
+    elif "ldherit" in fullPath:
+        return "LDherit"
+    elif "ldcorrelation" in fullPath:
+        return "LDcorrelation"
     elif "ldhap" in fullPath:
         return "LDhap"
     elif "ldmatrix" in fullPath:
@@ -1296,6 +1302,16 @@ def ldassoc():
 # @app.route('/LDlinkRest2/ldassoc', methods=['GET'])
 @app.route("/LDlinkRestWeb/ldscore", methods=["GET"])
 def ldscore():
+    request_started_at = time.time()
+    token_for_log = request.args.get("token", "NA")
+    module_for_log = "LDscore"
+    is_api_request = "LDlinkRestWeb" not in request.path
+
+    def _log_ldscore_access():
+        if is_api_request:
+            duration_ms = round((time.time() - request_started_at) * 1000)
+            logAccess(token_for_log, module_for_log, duration_ms)
+
     if "LDlinkRestWeb" in request.path:
         web = True
     else:
@@ -1320,6 +1336,7 @@ def ldscore():
         reference, fileDir = _resolve_upload_dir(reference)
     except ValueError as validation_error:
         app.logger.warning(f"Invalid LDscore reference: {validation_error}")
+        _log_ldscore_access()
         return sendTraceback(str(validation_error))
 
     inputfilename = "22"
@@ -1354,6 +1371,7 @@ def ldscore():
                     safe_fname, new_file_path, _ = _resolve_upload_file_path(fname, reference, create_dir=True)
                 except ValueError as validation_error:
                     app.logger.warning(f"Invalid LDscore filename: {validation_error}")
+                    _log_ldscore_access()
                     return sendTraceback(str(validation_error))
                 
                 if str(isExample).lower() == "true":
@@ -1365,9 +1383,11 @@ def ldscore():
                         app.logger.info(f"Copied example file {safe_fname} to {new_file_path}")
                     except (ValueError, FileNotFoundError) as copy_error:
                         app.logger.warning(f"Invalid LDscore example file request: {copy_error}")
+                        _log_ldscore_access()
                         return sendTraceback(str(copy_error))
                     except OSError as copy_error:
                         app.logger.error(f"Failed to copy LDscore example file: {copy_error}")
+                        _log_ldscore_access()
                         return sendTraceback("Unable to copy requested example file.")
                 else:
                     # For uploaded files, they are already in the reference folder from upload endpoint
@@ -1410,6 +1430,7 @@ def ldscore():
             # print(pretty_out_json)
             schedule_tmp_cleanup(reference, app.logger)
             schedule_tmp_cleanup_ldscore(reference, app.logger, tmp_dir=app.config["UPLOAD_DIR"])
+            _log_ldscore_access()
             return filtered_result
             out_json = pretty_out_json
 
@@ -1422,7 +1443,9 @@ def ldscore():
     app.logger.info("Executed LDscore (%ss)" % (round(end_time - start_time, 2)))
     schedule_tmp_cleanup(reference, app.logger)
     schedule_tmp_cleanup_ldscore(reference, app.logger, tmp_dir=app.config["UPLOAD_DIR"])
+    _log_ldscore_access()
     return jsonify(out_json)
+
 
 
 @app.route("/LDlinkRest/ldscoreapi", methods=["POST"])
@@ -1523,6 +1546,16 @@ def ldscoreapi():
 @app.route("/LDlinkRest/ldherit", methods=["GET"])
 @app.route("/LDlinkRestWeb/ldherit", methods=["GET"])
 def ldherit():
+    request_started_at = time.time()
+    token_for_log = request.args.get("token", "NA")
+    module_for_log = "LDherit"
+    is_api_request = "LDlinkRestWeb" not in request.path
+
+    def _log_ldherit_access():
+        if is_api_request:
+            duration_ms = round((time.time() - request_started_at) * 1000)
+            logAccess(token_for_log, module_for_log, duration_ms)
+
     if "LDlinkRestWeb" in request.path:
         web = True
     else:
@@ -1544,6 +1577,7 @@ def ldherit():
         scale, samp_prev, pop_prev = _validate_ldsc_scale_params(scale, samp_prev, pop_prev)
     except ValueError as validation_error:
         app.logger.warning(f"Invalid LDherit prevalence input: {validation_error}")
+        _log_ldherit_access()
         return sendTraceback(str(validation_error))
     app.logger.debug(
         f"LDherit params - pop: {pop}, genome_build: {genome_build}, filename: {filename}, isexample: {isexample}, scale: {scale}"
@@ -1556,6 +1590,7 @@ def ldherit():
         reference, fileDir = _resolve_upload_dir(reference)
     except ValueError as validation_error:
         app.logger.warning(f"Invalid LDherit reference: {validation_error}")
+        _log_ldherit_access()
         return sendTraceback(str(validation_error))
 
     app.logger.debug(f"LDherit processing filename: {filename}")
@@ -1566,6 +1601,7 @@ def ldherit():
             filename, new_file_path, _ = _resolve_upload_file_path(filename, reference, create_dir=True)
         except ValueError as validation_error:
             app.logger.warning(f"Invalid LDherit filename: {validation_error}")
+            _log_ldherit_access()
             return sendTraceback(str(validation_error))
         
         if str(isexample).lower() == "true":
@@ -1577,9 +1613,11 @@ def ldherit():
                 app.logger.info(f"Copied example file {safe_filename} to {new_file_path}")
             except (ValueError, FileNotFoundError) as copy_error:
                 app.logger.warning(f"Invalid LDherit example file request: {copy_error}")
+                _log_ldherit_access()
                 return sendTraceback(str(copy_error))
             except OSError as copy_error:
                 app.logger.error(f"Failed to copy LDherit example file: {copy_error}")
+                _log_ldherit_access()
                 return sendTraceback("Unable to copy requested example file.")
         else:
             # For uploaded files, they are already in the reference folder from upload endpoint
@@ -1616,6 +1654,7 @@ def ldherit():
             # print(pretty_out_json)
             schedule_tmp_cleanup(reference, app.logger)
             schedule_tmp_cleanup_ldscore(reference, app.logger, tmp_dir=app.config["UPLOAD_DIR"])
+            _log_ldherit_access()
             return filtered_result
             out_json = pretty_out_json
 
@@ -1628,6 +1667,7 @@ def ldherit():
     app.logger.info("Executed LDscore (%ss)" % (round(end_time - start_time, 2)))
     schedule_tmp_cleanup(reference, app.logger)
     schedule_tmp_cleanup_ldscore(reference, app.logger, tmp_dir=app.config["UPLOAD_DIR"])
+    _log_ldherit_access()
     return jsonify(out_json)
 
 
@@ -1732,6 +1772,16 @@ def ldheritAPI():
 @app.route("/LDlinkRest/ldcorrelation", methods=["GET"])
 @app.route("/LDlinkRestWeb/ldcorrelation", methods=["GET"])
 def ldcorrelation():
+    request_started_at = time.time()
+    token_for_log = request.args.get("token", "NA")
+    module_for_log = "LDcorrelation"
+    is_api_request = "LDlinkRestWeb" not in request.path
+
+    def _log_ldcorrelation_access():
+        if is_api_request:
+            duration_ms = round((time.time() - request_started_at) * 1000)
+            logAccess(token_for_log, module_for_log, duration_ms)
+
     if "LDlinkRestWeb" in request.path:
         web = True
     else:
@@ -1754,6 +1804,7 @@ def ldcorrelation():
         scale, samp_prev, pop_prev = _validate_ldsc_scale_params(scale, samp_prev, pop_prev, require_pair=True)
     except ValueError as validation_error:
         app.logger.warning(f"Invalid LDcorrelation prevalence input: {validation_error}")
+        _log_ldcorrelation_access()
         return sendTraceback(str(validation_error))
     app.logger.debug(
         f"LDcorrelation params - pop: {pop}, genome_build: {genome_build}, filename: {filename}, isexample: {isexample}, reference: {reference}, scale: {scale}"
@@ -1767,6 +1818,7 @@ def ldcorrelation():
         reference, fileDir = _resolve_upload_dir(reference)
     except ValueError as validation_error:
         app.logger.warning(f"Invalid LDcorrelation reference: {validation_error}")
+        _log_ldcorrelation_access()
         return sendTraceback(str(validation_error))
     
     # Handle file copying based on example vs uploaded
@@ -1776,6 +1828,7 @@ def ldcorrelation():
                 safe_fname, new_file_path, _ = _resolve_upload_file_path(fname, reference, create_dir=True)
             except ValueError as validation_error:
                 app.logger.warning(f"Invalid LDcorrelation filename: {validation_error}")
+                _log_ldcorrelation_access()
                 return sendTraceback(str(validation_error))
             
             if str(isexample).lower() == "true":
@@ -1787,9 +1840,11 @@ def ldcorrelation():
                     app.logger.info(f"Copied example file {safe_fname} to {new_file_path}")
                 except (ValueError, FileNotFoundError) as copy_error:
                     app.logger.warning(f"Invalid LDcorrelation example file request: {copy_error}")
+                    _log_ldcorrelation_access()
                     return sendTraceback(str(copy_error))
                 except OSError as copy_error:
                     app.logger.error(f"Failed to copy LDcorrelation example file: {copy_error}")
+                    _log_ldcorrelation_access()
                     return sendTraceback("Unable to copy requested example file.")
             else:
                 # For uploaded files, they are already in the reference folder from upload endpoint
@@ -1833,6 +1888,7 @@ def ldcorrelation():
             # print(pretty_out_json)
             schedule_tmp_cleanup(reference, app.logger)
             schedule_tmp_cleanup_ldscore(reference, app.logger, tmp_dir=app.config["UPLOAD_DIR"])
+            _log_ldcorrelation_access()
             return filtered_result
             out_json = pretty_out_json
 
@@ -1845,6 +1901,7 @@ def ldcorrelation():
     app.logger.info("Executed LDscore (%ss)" % (round(end_time - start_time, 2)))
     schedule_tmp_cleanup(reference, app.logger)
     schedule_tmp_cleanup_ldscore(reference, app.logger, tmp_dir=app.config["UPLOAD_DIR"])
+    _log_ldcorrelation_access()
     return jsonify(out_json)
 
 

--- a/server/LDlink.py
+++ b/server/LDlink.py
@@ -31,12 +31,14 @@ from SNPchip import calculate_chip, get_platform_request
 from ApiAccess import (
     register_user,
     checkToken,
+    getTokenRuntimeLast24Hours,
     checkApiServer2Auth,
     checkBlocked,
     checkLocked,
     toggleLocked,
     logAccess,
     emailJustification,
+    blockToken,
     blockUser,
     unblockUser,
     getStats,
@@ -381,11 +383,31 @@ def requires_token(f):
                         return sendTraceback(
                             "Concurrent API requests restricted. Please limit usage to sequential requests only. Contact system administrator if you have issues accessing API: NCILDlinkWebAdmin@mail.nih.gov"
                         )
+                total_runtime_ms_24h = getTokenRuntimeLast24Hours(token)
+                request.environ["token_runtime_ms_24h"] = total_runtime_ms_24h
+                runtime_limit_ms_24h = 10000
+
+                if total_runtime_ms_24h > runtime_limit_ms_24h:
+                    blockToken(token, url_root)
+                    app.logger.warning(
+                        "Blocked token due to runtime limit. module=%s runtime_ms_24h=%d limit_ms_24h=%d",
+                        getModule(request.full_path),
+                        total_runtime_ms_24h,
+                        runtime_limit_ms_24h,
+                    )
+                    return sendTraceback(
+                        "Your API token has been blocked because runtime usage exceeded the 24-hour test limit. Please contact system administrator: NCILDlinkWebAdmin@mail.nih.gov"
+                    )
                 # Check if token has been authorized to access api server 2
                 # if ("LDlinkRest2" in request.full_path):
                 #    if not checkApiServer2Auth(token):
                 #        return sendTraceback("Your token is not authorized to access this API endpoint. Please contact system administrator: NCILDlinkWebAdmin@mail.nih.gov")
                 module = getModule(request.full_path)
+                app.logger.info(
+                    "Token runtime 24h check for %s: %.2f minutes",
+                    module,
+                    total_runtime_ms_24h / 60000.0,
+                )
                 request_started_at = time.time()
                 try:
                     return f(*args, **kwargs)

--- a/server/LDlink.py
+++ b/server/LDlink.py
@@ -380,12 +380,20 @@ def requires_token(f):
                 #    if not checkApiServer2Auth(token):
                 #        return sendTraceback("Your token is not authorized to access this API endpoint. Please contact system administrator: NCILDlinkWebAdmin@mail.nih.gov")
                 module = getModule(request.full_path)
-                logAccess(token, module)
-                return f(*args, **kwargs)
+                request_started_at = time.time()
+                try:
+                    return f(*args, **kwargs)
+                finally:
+                    duration_ms = round((time.time() - request_started_at) * 1000)
+                    logAccess(token, module, duration_ms)
             token = "NA"
             module = getModule(request.full_path)
-            logAccess(token, module)
-            return f(*args, **kwargs)
+            request_started_at = time.time()
+            try:
+                return f(*args, **kwargs)
+            finally:
+                duration_ms = round((time.time() - request_started_at) * 1000)
+                logAccess(token, module, duration_ms)
         return f(*args, **kwargs)
 
     return decorated_function

--- a/server/LDlink.py
+++ b/server/LDlink.py
@@ -385,7 +385,7 @@ def requires_token(f):
                         )
                 total_runtime_ms_24h = getTokenRuntimeLast24Hours(token)
                 request.environ["token_runtime_ms_24h"] = total_runtime_ms_24h
-                runtime_limit_ms_24h = 10000
+                runtime_limit_ms_24h = param_list["runtime_limit_ms_24h"]
                 
                 app.logger.info(
                     "Runtime budget check: token=%s total_runtime_ms_24h=%d limit_ms_24h=%d comparison_result=%s",

--- a/server/LDlink.py
+++ b/server/LDlink.py
@@ -386,15 +386,24 @@ def requires_token(f):
                 total_runtime_ms_24h = getTokenRuntimeLast24Hours(token)
                 request.environ["token_runtime_ms_24h"] = total_runtime_ms_24h
                 runtime_limit_ms_24h = 10000
+                
+                app.logger.info(
+                    "Runtime budget check: token=%s total_runtime_ms_24h=%d limit_ms_24h=%d comparison_result=%s",
+                    token,
+                    total_runtime_ms_24h,
+                    runtime_limit_ms_24h,
+                    "OVER_LIMIT" if total_runtime_ms_24h > runtime_limit_ms_24h else "UNDER_LIMIT"
+                )
 
                 if total_runtime_ms_24h > runtime_limit_ms_24h:
-                    blockToken(token, url_root)
                     app.logger.warning(
-                        "Blocked token due to runtime limit. module=%s runtime_ms_24h=%d limit_ms_24h=%d",
-                        getModule(request.full_path),
+                        "BLOCKING TOKEN: token=%s total_runtime_ms_24h=%d exceeded limit=%d module=%s",
+                        token,
                         total_runtime_ms_24h,
                         runtime_limit_ms_24h,
+                        getModule(request.full_path),
                     )
+                    blockToken(token, url_root)
                     return sendTraceback(
                         "Your API token has been blocked because runtime usage exceeded the 24-hour test limit. Please contact system administrator: NCILDlinkWebAdmin@mail.nih.gov"
                     )

--- a/server/LDutilites.py
+++ b/server/LDutilites.py
@@ -39,6 +39,10 @@ def get_config():
     config['restrict_concurrency'] = environ.get('RESTRICT_CONCURRENCY') == 'YES'
     config['token_lock_timeout'] = int(environ.get('TOKEN_LOCK_TIMEOUT', 900))
     config['runtime_limit_ms_24h'] = int(environ.get('RUNTIME_LIMIT_MS_24H', 86400000))
+    runtime_block_cooldown_minutes = environ.get('RUNTIME_BLOCK_COOLDOWN_MINUTES')
+    if runtime_block_cooldown_minutes is None:
+        runtime_block_cooldown_minutes = int(environ.get('RUNTIME_BLOCK_COOLDOWN_HOURS', 12)) * 60
+    config['runtime_block_cooldown_minutes'] = int(runtime_block_cooldown_minutes)
 
     config['email_smtp_host'] = environ.get('EMAIL_SMTP_HOST')
     config['email_admin'] = environ.get('EMAIL_ADMIN')

--- a/server/LDutilites.py
+++ b/server/LDutilites.py
@@ -38,6 +38,7 @@ def get_config():
     config['token_expiration_days'] = int(environ.get('TOKEN_EXPIRATION_DAYS'))
     config['restrict_concurrency'] = environ.get('RESTRICT_CONCURRENCY') == 'YES'
     config['token_lock_timeout'] = int(environ.get('TOKEN_LOCK_TIMEOUT', 900))
+    config['runtime_limit_ms_24h'] = int(environ.get('RUNTIME_LIMIT_MS_24H', 86400000))
 
     config['email_smtp_host'] = environ.get('EMAIL_SMTP_HOST')
     config['email_admin'] = environ.get('EMAIL_ADMIN')


### PR DESCRIPTION
Add runtime-based quota and auto-lock
•	Store per-request duration in api_log as duration_ms field.
•	Aggregate cumulative runtime per token over rolling 24-hour window (now - 24h).
•	When cumulative runtime exceeds threshold, block token for cooldown period.
•	Auto-unblock after cooldown expires; only runtime-limit blocks auto-expire (admin blocks stay permanent).
•	Use fresh budget window (runtime_budget_reset_at) on auto-unblock to prevent re-block from old logs.
